### PR TITLE
Fix cc.exe turning into c?.exe

### DIFF
--- a/Launcher/Utils/Game.cs
+++ b/Launcher/Utils/Game.cs
@@ -69,13 +69,13 @@ namespace Launcher.Utils
             {
                 if (Argument.Exists("--debug-mode"))
                     Terminal.Debug("Launching the game without Game Coordinator...");
-                _process.StartInfo.FileName = $"{directory}/csgo.exe";
+                _process.StartInfo.FileName = $"{directory}\\csgo.exe";
             }
             else
             {
                 if (Argument.Exists("--debug-mode"))
                     Terminal.Debug("Launching the game with Game Coordinator...");
-                _process.StartInfo.FileName = $"{directory}/cс.exe";
+                _process.StartInfo.FileName = $"{directory}\\cc.exe";
             }
             _process.StartInfo.Arguments = string.Join(" ", arguments);
 


### PR DESCRIPTION
During launch of cc with game coordinator you would get error that file .../c?.exe doesn't exist.

The problem of {directory}\\cc.exe turning into {directory}\\c?.exe was because the 2nd "c" was cyrlic c and since its not Latin letter, it would just change it into "?"